### PR TITLE
Target Spring Boot 2.0.2 and Broadleaf 6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.0.1.RELEASE</version>
+        <version>2.0.2.RELEASE</version>
         <relativePath />
     </parent>
     <groupId>org.broadleafcommerce</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>1.5.12.RELEASE</version>
+        <version>2.0.1.RELEASE</version>
         <relativePath />
     </parent>
     <groupId>org.broadleafcommerce</groupId>
@@ -14,10 +14,9 @@
     <description>Contains configuration for a Broadleaf Commerce Spring Boot starter project</description>
 
     <properties>
-        <hibernate.version>4.1.11.Final</hibernate.version>
+        <hibernate.version>5.2.17.Final</hibernate.version>
         <solr.version>5.3.1</solr.version>
         <hsqldb.version>2.4.0</hsqldb.version>
-        <thymeleaf.version>3.0.9.RELEASE</thymeleaf.version>
         <broadleaf.bom.version>6.0.0-SNAPSHOT</broadleaf.bom.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,6 @@
     <description>Contains configuration for a Broadleaf Commerce Spring Boot starter project</description>
 
     <properties>
-        <hibernate.version>5.2.17.Final</hibernate.version>
         <solr.version>5.3.1</solr.version>
         <hsqldb.version>2.4.0</hsqldb.version>
         <broadleaf.bom.version>6.0.0-SNAPSHOT</broadleaf.bom.version>


### PR DESCRIPTION
We can remove some of our overridden dependency versions because Spring Boot now includes our required versions of Hibernate (5.2.17) and Thymeleaf (3.0.9). See [the Boot-defined dependencies](https://github.com/spring-projects/spring-boot/blob/v2.0.2.RELEASE/spring-boot-project/spring-boot-dependencies/pom.xml).