### PR TITLE
Update/override log4j version that springboot has as poi in importer needs a higher version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,7 @@
         <spring.version>5.0.20.RELEASE</spring.version>
         <spring-security.version>5.0.19.RELEASE</spring-security.version>
         <broadleaf.bom.version>6.0.20-SNAPSHOT</broadleaf.bom.version>
+        <log4j2.version>2.18.0</log4j2.version>
     </properties>
 
     <scm>


### PR DESCRIPTION
spring boot brings old version of log4j & its dependencies and poi needs a higher version

Fixes: BroadleafCommerce/QA#5087