### PR TITLE
Upgrade to latest Spring libraries (6.2.10)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
         <hibernate.version>6.2.31.Final</hibernate.version>
         <spring-security.version>6.5.3</spring-security.version>
         <spring-ldap-core.version>3.3.3</spring-ldap-core.version>
-        <spring-framework.version>6.2.10</spring-framework.version>
+        <spring-framework.version>6.2.11</spring-framework.version>
         <thymeleaf.layout.version>3.3.0</thymeleaf.layout.version>
         <broadleaf.bom.version>7.0.6-SNAPSHOT</broadleaf.bom.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.1.12</version>
+        <version>3.5.5</version>
         <relativePath />
     </parent>
 
@@ -25,8 +25,9 @@
         <thymeleaf.version>3.1.3.RELEASE</thymeleaf.version>
         <commons-lang3.version>3.18.0</commons-lang3.version>
         <hibernate.version>6.2.31.Final</hibernate.version>
-        <spring-security.version>6.1.9</spring-security.version>
-        <spring-framework.version>6.0.23</spring-framework.version>
+        <spring-security.version>6.5.3</spring-security.version>
+        <spring-ldap-core.version>3.3.3</spring-ldap-core.version>
+        <spring-framework.version>6.2.10</spring-framework.version>
         <thymeleaf.layout.version>3.3.0</thymeleaf.layout.version>
         <broadleaf.bom.version>7.0.6-SNAPSHOT</broadleaf.bom.version>
     </properties>


### PR DESCRIPTION
Supporting the changes made in https://github.com/BroadleafCommerce/QA/issues/5419 to upgrade to the lates Spring 6.2.x releases.