### PR TITLE
Spring Security update to 6.5.9 fix version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <thymeleaf.version>3.1.3.RELEASE</thymeleaf.version>
         <commons-lang3.version>3.18.0</commons-lang3.version>
         <hibernate.version>5.6.15.Final</hibernate.version>
-        <spring-security.version>6.5.5</spring-security.version>
+        <spring-security.version>6.5.9</spring-security.version>
         <spring-ldap-core.version>3.3.3</spring-ldap-core.version>
         <spring-framework.version>6.2.11</spring-framework.version>
         <thymeleaf.layout.version>3.3.0</thymeleaf.layout.version>


### PR DESCRIPTION
BroadleafCommerce/QA#5467

- Update Spring Security to the fix version `6.5.9`